### PR TITLE
[WIP] mev claim instructions

### DIFF
--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -92,6 +92,9 @@ pub enum SinglePoolError {
     /// Attempted to initialize a pool that is already initialized.
     #[error("PoolAlreadyInitialized")]
     PoolAlreadyInitialized,
+    /// There aren't enough excess lamps (i.e. MEV rewards) to create a temp account
+    #[error("NotEnoughExcessLamps")]
+    InsufficientExcessLamports,
 }
 impl From<SinglePoolError> for ProgramError {
     fn from(e: SinglePoolError) -> Self {
@@ -152,6 +155,8 @@ impl PrintProgramError for SinglePoolError {
                 msg!("Error: Attempted to deposit from or withdraw to pool stake account."),
             SinglePoolError::PoolAlreadyInitialized =>
                 msg!("Error: Attempted to initialize a pool that is already initialized."),
+            SinglePoolError::InsufficientExcessLamports =>
+                msg!("Error: There are not enough excess lamps in the pool to init a temporary staking account."),
         }
     }
 }

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -44,30 +44,6 @@ pub enum SinglePoolInstruction {
     ///  12. `[]` Stake program
     InitializePool,
 
-    // TODO comment
-    ///   0. `[]` Pool account
-    ///   1. `[w]` Temp stake account
-    ///   3. `[]` Pool stake authority
-    ///   4. `[]` Vote account
-    ///   5. `[]` Rent sysvar
-    ///   6. `[]` Clock sysvar
-    ///   7. `[]` Stake history sysvar
-    ///   8. `[]` Stake config sysvar
-    ///   9. `[]` System program
-    ///  10. `[]` Stake program
-    InitializeTempStake,
-
-    // TODO comment
-    ///   0. `[]` Pool account
-    ///   1. `[w]` Pool stake account
-    ///   2. `[w]` Temp stake account
-    ///   3. `[]` Pool stake authority
-    ///   4. `[]` Clock sysvar
-    ///   5. `[]` Stake history sysvar
-    ///   6. `[]` System program
-    ///   7. `[]` Stake program
-    ProcessMergeTempStake,
-
     ///   Restake the pool stake account if it was deactivated. This can
     ///   happen through the stake program's `DeactivateDelinquent`
     ///   instruction, or during a cluster restart.
@@ -152,6 +128,29 @@ pub enum SinglePoolInstruction {
         /// URI of the uploaded metadata of the spl-token
         uri: String,
     },
+    // TODO comment
+    ///   0. `[]` Pool account
+    ///   1. `[w]` Temp stake account
+    ///   3. `[]` Pool stake authority
+    ///   4. `[]` Vote account
+    ///   5. `[]` Rent sysvar
+    ///   6. `[]` Clock sysvar
+    ///   7. `[]` Stake history sysvar
+    ///   8. `[]` Stake config sysvar
+    ///   9. `[]` System program
+    ///  10. `[]` Stake program
+    InitializeTempStake,
+
+    // TODO comment
+    ///   0. `[]` Pool account
+    ///   1. `[w]` Pool stake account
+    ///   2. `[w]` Temp stake account
+    ///   3. `[]` Pool stake authority
+    ///   4. `[]` Clock sysvar
+    ///   5. `[]` Stake history sysvar
+    ///   6. `[]` System program
+    ///   7. `[]` Stake program
+    ProcessMergeTempStake,
 }
 
 /// Creates all necessary instructions to initialize the stake pool.

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -44,6 +44,30 @@ pub enum SinglePoolInstruction {
     ///  12. `[]` Stake program
     InitializePool,
 
+    // TODO comment
+    ///   0. `[]` Pool account
+    ///   1. `[w]` Temp stake account
+    ///   3. `[]` Pool stake authority
+    ///   4. `[]` Vote account
+    ///   5. `[]` Rent sysvar
+    ///   6. `[]` Clock sysvar
+    ///   7. `[]` Stake history sysvar
+    ///   8. `[]` Stake config sysvar
+    ///   9. `[]` System program
+    ///  10. `[]` Stake program
+    InitializeTempStake,
+
+    // TODO comment
+    ///   0. `[]` Pool account
+    ///   1. `[w]` Pool stake account
+    ///   2. `[w]` Temp stake account
+    ///   3. `[]` Pool stake authority
+    ///   4. `[]` Clock sysvar
+    ///   5. `[]` Stake history sysvar
+    ///   6. `[]` System program
+    ///   7. `[]` Stake program
+    ProcessMergeTempStake,
+
     ///   Restake the pool stake account if it was deactivated. This can
     ///   happen through the stake program's `DeactivateDelinquent`
     ///   instruction, or during a cluster restart.

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -20,6 +20,7 @@ solana_program::declare_id!("SVSPxpvHdN29nkVg9rPapPNDddN5DipNLRUFhyjFThE");
 
 const POOL_PREFIX: &[u8] = b"pool";
 const POOL_STAKE_PREFIX: &[u8] = b"stake";
+const POOL_TEMP_STAKE_PREFIX: &[u8] = b"temp_stake";
 const POOL_MINT_PREFIX: &[u8] = b"mint";
 const POOL_MINT_AUTHORITY_PREFIX: &[u8] = b"mint_authority";
 const POOL_STAKE_AUTHORITY_PREFIX: &[u8] = b"stake_authority";
@@ -37,6 +38,10 @@ fn find_pool_address_and_bump(program_id: &Pubkey, vote_account_address: &Pubkey
 
 fn find_pool_stake_address_and_bump(program_id: &Pubkey, pool_address: &Pubkey) -> (Pubkey, u8) {
     Pubkey::find_program_address(&[POOL_STAKE_PREFIX, pool_address.as_ref()], program_id)
+}
+
+fn find_pool_temp_stake_address_and_bump(program_id: &Pubkey, pool_address: &Pubkey) -> (Pubkey, u8) {
+    Pubkey::find_program_address(&[POOL_TEMP_STAKE_PREFIX, pool_address.as_ref()], program_id)
 }
 
 fn find_pool_mint_address_and_bump(program_id: &Pubkey, pool_address: &Pubkey) -> (Pubkey, u8) {

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -1388,6 +1388,14 @@ impl Processor {
                 msg!("Instruction: InitializePool");
                 Self::process_initialize_pool(program_id, accounts)
             }
+            SinglePoolInstruction::InitializeTempStake => {
+                msg!("Instruction: InitializeTempPool");
+                Self::process_initialize_temp_stake(program_id, accounts)
+            }
+            SinglePoolInstruction::ProcessMergeTempStake => {
+                msg!("Instruction: MergeTempStake");
+                Self::process_merge_temp_stake(program_id, accounts)
+            }
             SinglePoolInstruction::ReactivatePoolStake => {
                 msg!("Instruction: ReactivatePoolStake");
                 Self::process_reactivate_pool_stake(program_id, accounts)

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -1388,14 +1388,6 @@ impl Processor {
                 msg!("Instruction: InitializePool");
                 Self::process_initialize_pool(program_id, accounts)
             }
-            SinglePoolInstruction::InitializeTempStake => {
-                msg!("Instruction: InitializeTempPool");
-                Self::process_initialize_temp_stake(program_id, accounts)
-            }
-            SinglePoolInstruction::ProcessMergeTempStake => {
-                msg!("Instruction: MergeTempStake");
-                Self::process_merge_temp_stake(program_id, accounts)
-            }
             SinglePoolInstruction::ReactivatePoolStake => {
                 msg!("Instruction: ReactivatePoolStake");
                 Self::process_reactivate_pool_stake(program_id, accounts)
@@ -1423,6 +1415,14 @@ impl Processor {
             SinglePoolInstruction::UpdateTokenMetadata { name, symbol, uri } => {
                 msg!("Instruction: UpdateTokenMetadata");
                 Self::process_update_pool_token_metadata(program_id, accounts, name, symbol, uri)
+            }
+            SinglePoolInstruction::InitializeTempStake => {
+                msg!("Instruction: InitializeTempPool");
+                Self::process_initialize_temp_stake(program_id, accounts)
+            }
+            SinglePoolInstruction::ProcessMergeTempStake => {
+                msg!("Instruction: MergeTempStake");
+                Self::process_merge_temp_stake(program_id, accounts)
             }
         }
     }


### PR DESCRIPTION
Claiming MEV rewards (which are just SOL chilling in the pool_stake account), will be a two-step process:
1) `process_initialize_temp_stake` creates a second single-pool program owned stake account just like the main pool and sweeps all the excess SOL into it
2) `process_merge_temp_stake` merges the temp pool into the main pool, without claiming any vouchers, which automatically splits that stake among depositors

WIP

* An attacker can deposit -> process_merge_temp_stake -> instantly withdraw to steal some MEV.
* Deposit should now (1) check that `process_initialize_temp_stake` has run recently (let's say one month) or fail (if the pool itself is less than one month old, we also allow the deposit), (2) check if `process_merge_temp_stake` is eligible to run (the temp stake account is active) and crank it if so.
* We may want to add some small SOL incentive to running the crank